### PR TITLE
[codex] Improve build portability and user install

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,12 +12,13 @@ nv-monitor is a single-file C terminal system monitor for the NVIDIA DGX Spark (
 make          # builds nv-monitor binary (-O3 -march=native)
 make portable # builds without -march=native (for CI/distribution)
 make test     # builds and runs unit tests
+make install-user # installs to ~/.local/bin by default
 make clean    # removes binaries
 ```
 
-Direct compilation: `gcc -O2 -Wall -Wextra -std=gnu11 -o nv-monitor nv-monitor.c -lncursesw -ldl -lpthread`
+Direct compilation: `cc -O2 -Wall -Wextra -std=gnu11 -o nv-monitor nv-monitor.c -lncursesw -ldl -lpthread`
 
-Dependencies: `build-essential`, `libncurses-dev`
+Dependencies: a C compiler (`cc`, `gcc`, or `clang`) and `libncurses-dev`
 
 Works on both **aarch64** (DGX Spark) and **x86_64**. On x86, ARM core type labels are omitted; everything else works identically.
 

--- a/Makefile
+++ b/Makefile
@@ -1,29 +1,60 @@
-CC      = gcc
-VERSION = $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
-CFLAGS  = -O3 -march=native -flto -Wall -Wextra -std=gnu11 -DVERSION='"$(VERSION)"'
-CFLAGS_PORTABLE = -O3 -flto -Wall -Wextra -std=gnu11 -DVERSION='"$(VERSION)"'
-LDFLAGS = -lncursesw -ldl -lpthread
+CC ?= cc
+VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
+PREFIX ?= /usr/local
+BINDIR ?= $(PREFIX)/bin
+USER_BINDIR ?= $(HOME)/.local/bin
+
+COMMON_CFLAGS = -Wall -Wextra -std=gnu11
+# Detect Clang even when it is invoked as `cc`; we avoid defaulting to `-flto`
+# there to sidestep linker-plugin mismatches on GNU ld-based setups.
+CC_VERSION_TEXT := $(shell $(CC) --version 2>/dev/null | sed -n '1p')
+ifneq ($(findstring clang,$(CC_VERSION_TEXT)),)
+LTO_CFLAGS ?=
+else
+LTO_CFLAGS ?= -flto
+endif
+
+# Project defaults live in the *_CFLAGS variables below.
+# Use `make portable` to drop `-march=native`; `CFLAGS=...` adds user flags.
+NATIVE_CFLAGS = -O3 -march=native $(LTO_CFLAGS)
+# Portable drops `-march=native`; LTO is retained where the compiler supports it.
+PORTABLE_CFLAGS = -O3 $(LTO_CFLAGS)
+DEMO_CFLAGS = -O2
+TEST_CFLAGS = -O0
+
+VERSION_CPPFLAGS = -DVERSION='"$(VERSION)"'
+NV_MONITOR_LDLIBS = -lncursesw -ldl -lpthread
+# Keep demo-load isolated unless the caller explicitly opts into extra linker flags.
+DEMO_LDFLAGS ?=
+DEMO_LDLIBS = -lpthread -ldl -lm
+# test_meminfo is intentionally self-contained and does not need ncurses/NVML libs.
+TEST_LDLIBS =
 TARGET  = nv-monitor
 
 all: $(TARGET)
 
 $(TARGET): nv-monitor.c
-	$(CC) $(CFLAGS) -o $@ $< $(LDFLAGS)
+	$(CC) $(CPPFLAGS) $(VERSION_CPPFLAGS) $(COMMON_CFLAGS) $(NATIVE_CFLAGS) $(CFLAGS) -o $@ $< $(LDFLAGS) $(LDLIBS) $(NV_MONITOR_LDLIBS)
 
 demo-load: demo-load.c
-	$(CC) -O2 -Wall -Wextra -o demo-load demo-load.c -lpthread -ldl -lm
+	$(CC) $(CPPFLAGS) $(COMMON_CFLAGS) $(DEMO_CFLAGS) $(CFLAGS) -o demo-load demo-load.c $(DEMO_LDFLAGS) $(DEMO_LDLIBS)
 
 portable:
-	$(CC) $(CFLAGS_PORTABLE) -o $(TARGET) nv-monitor.c $(LDFLAGS)
+	$(CC) $(CPPFLAGS) $(VERSION_CPPFLAGS) $(COMMON_CFLAGS) $(PORTABLE_CFLAGS) $(CFLAGS) -o $(TARGET) nv-monitor.c $(LDFLAGS) $(LDLIBS) $(NV_MONITOR_LDLIBS)
 
 test: test_meminfo.c
-	$(CC) -O0 -Wall -Wextra -o test_meminfo test_meminfo.c
+	$(CC) $(COMMON_CFLAGS) $(TEST_CFLAGS) -o test_meminfo test_meminfo.c $(TEST_LDLIBS)
 	./test_meminfo
 
 clean:
 	rm -f $(TARGET) demo-load test_meminfo
 
 install: $(TARGET)
-	install -m 755 $(TARGET) /usr/local/bin/
+	install -d $(BINDIR)
+	install -m 755 $(TARGET) $(BINDIR)/
 
-.PHONY: all portable test clean install
+install-user: $(TARGET)
+	install -d $(USER_BINDIR)
+	install -m 755 $(TARGET) $(USER_BINDIR)/
+
+.PHONY: all portable test clean install install-user

--- a/README.md
+++ b/README.md
@@ -60,12 +60,18 @@ For the reckless among you, there's a [binary release](https://github.com/wentba
 
 ## Building
 
-Requires `gcc` and `libncurses-dev`:
+Requires a C compiler (`cc`, `gcc`, or `clang`) and `libncurses-dev`:
 
 ```bash
 sudo apt install build-essential libncurses-dev
 make
 ```
+
+`make` builds an optimized binary for the current machine. Use `make portable`
+for a generic build without `-march=native`.
+
+If you pass `CFLAGS=...`, those flags are added on top of the project defaults.
+Use `make portable` rather than trying to strip `-march=native` via `CFLAGS`.
 
 ## Usage
 
@@ -83,6 +89,19 @@ Or install system-wide:
 
 ```bash
 sudo make install
+```
+
+Or install just for your user:
+
+```bash
+make install-user
+```
+
+`install-user` defaults to `~/.local/bin`. You can override the destination, for example:
+
+```bash
+make install-user USER_BINDIR="$HOME/.bin"
+make install BINDIR="$HOME/.bin"
 ```
 
 ### Command-line options


### PR DESCRIPTION
## Summary

- make the build compiler-agnostic by defaulting to `cc` and splitting project defaults from user override slots
- add `PREFIX`/`BINDIR`/`USER_BINDIR` support plus `make install-user` for user-local installs
- document portable builds, additive `CFLAGS`, and the new user-local install flow in the README and CLAUDE notes

## Why

The project built locally, but the Makefile assumed a literal `gcc` binary and only supported system-wide installation. That makes the build less portable across environments and makes local installs awkward for users who want `~/.local/bin` or a custom bin dir.

This change keeps the existing optimized default build, preserves a portable target for generic binaries, and adds a first-class user install path without introducing new dependencies.

## Implementation Notes

- keep `nv-monitor` and `portable` using project-owned flags and libraries while still allowing user `CFLAGS`/`LDFLAGS`/`LDLIBS` additions
- retain LTO where enabled by default and document the conservative clang behavior in the Makefile comments
- keep `demo-load` and `test_meminfo` intentionally isolated so helper targets do not silently inherit unrelated link requirements

## Validation

- `make all demo-load test`
- `CC=cc make clean portable demo-load test`
