### PR TITLE
Fix Prometheus decimal format on non-English locales

### DIFF
--- a/nv-monitor.c
+++ b/nv-monitor.c
@@ -1754,6 +1754,7 @@ static void draw_screen(void) {
 
 int main(int argc, char *argv[]) {
     setlocale(LC_ALL, "");
+    setlocale(LC_NUMERIC, "C"); /* Force decimal point for Prometheus exposition format */
     signal(SIGINT,  on_signal);
     signal(SIGTERM, on_signal);
 


### PR DESCRIPTION
## Summary
Locales like `es_ES.UTF-8` cause `snprintf("%.2f")` to produce commas instead of dots (e.g. `1,00` vs `1.00`), breaking Prometheus exposition format.

Fix: `setlocale(LC_NUMERIC, "C")` after `setlocale(LC_ALL, "")` — forces decimal points for numeric output without breaking Unicode/ncursesw.

Credit: community bug report from a Spanish locale user.