### PR TITLE
Multi-GPU support for CSV logging and demo-load

### DIFF
--- a/demo-load.c
+++ b/demo-load.c
@@ -160,13 +160,18 @@ typedef void *CUmodule;
 typedef void *CUfunction;
 typedef void *CUstream;
 
+typedef struct {
+    int gpu_index;
+} GpuThreadArg;
+
 static void *gpu_load_thread(void *arg) {
-    (void)arg;
+    GpuThreadArg *ga = (GpuThreadArg *)arg;
+    int gpu_idx = ga->gpu_index;
+    free(ga);
 
     void *cuda = dlopen("libcuda.so.1", RTLD_LAZY);
     if (!cuda) {
         fprintf(stderr, "demo-load: cannot open libcuda.so.1: %s\n", dlerror());
-        fprintf(stderr, "           GPU load disabled, run without --gpu\n");
         return NULL;
     }
 
@@ -184,7 +189,6 @@ static void *gpu_load_thread(void *arg) {
     CUresult (*cuStreamCreate)(CUstream *, unsigned) = dlsym(cuda, "cuStreamCreate");
     CUresult (*cuStreamSynchronize)(CUstream) = dlsym(cuda, "cuStreamSynchronize");
     CUresult (*cuStreamDestroy)(CUstream) = dlsym(cuda, "cuStreamDestroy_v2");
-
     if (!cuInit || !cuDeviceGet || !cuCtxCreate || !cuModuleLoadData ||
         !cuModuleGetFunction || !cuLaunchKernel || !cuCtxSynchronize || !cuCtxDestroy ||
         !cuStreamCreate || !cuStreamSynchronize || !cuStreamDestroy) {
@@ -201,18 +205,18 @@ static void *gpu_load_thread(void *arg) {
     }
 
     int dev = 0;
-    cuDeviceGet(&dev, 0);
+    cuDeviceGet(&dev, gpu_idx);
 
     CUcontext ctx = NULL;
     if ((rc = cuCtxCreate(&ctx, 0, dev)) != 0) {
-        fprintf(stderr, "demo-load: cuCtxCreate failed (%d)\n", rc);
+        fprintf(stderr, "demo-load: cuCtxCreate failed for GPU %d (%d)\n", gpu_idx, rc);
         dlclose(cuda);
         return NULL;
     }
 
     CUmodule mod = NULL;
     if ((rc = cuModuleLoadData(&mod, ptx_source)) != 0) {
-        fprintf(stderr, "demo-load: cuModuleLoadData failed (%d) — GPU may not support sm_50\n", rc);
+        fprintf(stderr, "demo-load: cuModuleLoadData failed for GPU %d (%d)\n", gpu_idx, rc);
         cuCtxDestroy(ctx);
         dlclose(cuda);
         return NULL;
@@ -227,7 +231,7 @@ static void *gpu_load_thread(void *arg) {
     /* ── Calibrate: measure how long one kernel takes ── */
     unsigned int blocks = gpu_blocks;
 
-    printf("Calibrating GPU load...");
+    printf("GPU %d: calibrating...", gpu_idx);
     fflush(stdout);
 
     /* Warm up */
@@ -253,7 +257,7 @@ static void *gpu_load_thread(void *arg) {
     struct timespec ts_start;
     clock_gettime(CLOCK_MONOTONIC, &ts_start);
 
-    printf("GPU load active (Ctrl-C to stop)\n");
+    printf("GPU %d: load active\n", gpu_idx);
 
     /*
      * Duty-cycle in 500ms windows (NVML samples at ~1s).
@@ -370,8 +374,9 @@ int main(int argc, char **argv) {
     if (ncpus < 1) ncpus = 1;
 
     pthread_t *cpu_threads = NULL;
-    pthread_t gpu_thread;
-    int gpu_started = 0;
+    #define MAX_GPUS 16
+    pthread_t gpu_threads[MAX_GPUS];
+    int n_gpus = 0;
 
     if (do_cpu) {
         printf("Starting CPU load on %d cores (sinusoidal, phased)\n", ncpus);
@@ -385,9 +390,31 @@ int main(int argc, char **argv) {
     }
 
     if (do_gpu) {
-        printf("Starting GPU load (sinusoidal)\n");
-        pthread_create(&gpu_thread, NULL, gpu_load_thread, NULL);
-        gpu_started = 1;
+        /* Detect GPU count via CUDA driver API */
+        void *cuda = dlopen("libcuda.so.1", RTLD_LAZY);
+        if (cuda) {
+            CUresult (*cuInit)(unsigned) = dlsym(cuda, "cuInit");
+            CUresult (*cuDeviceGetCount)(int *) = dlsym(cuda, "cuDeviceGetCount");
+            if (cuInit && cuDeviceGetCount && cuInit(0) == 0) {
+                int count = 0;
+                cuDeviceGetCount(&count);
+                if (count > MAX_GPUS) count = MAX_GPUS;
+                n_gpus = count;
+            }
+            dlclose(cuda);
+        }
+
+        if (n_gpus == 0) {
+            fprintf(stderr, "demo-load: no GPUs found\n");
+        } else {
+            printf("Starting GPU load on %d GPU%s (sinusoidal)\n",
+                   n_gpus, n_gpus > 1 ? "s" : "");
+            for (int g = 0; g < n_gpus; g++) {
+                GpuThreadArg *ga = malloc(sizeof(GpuThreadArg));
+                ga->gpu_index = g;
+                pthread_create(&gpu_threads[g], NULL, gpu_load_thread, ga);
+            }
+        }
     }
 
     if (stop_at > 0) {
@@ -415,8 +442,8 @@ int main(int argc, char **argv) {
             pthread_join(cpu_threads[i], NULL);
         free(cpu_threads);
     }
-    if (gpu_started)
-        pthread_join(gpu_thread, NULL);
+    for (int g = 0; g < n_gpus; g++)
+        pthread_join(gpu_threads[g], NULL);
 
     printf("Done.\n");
     return 0;

--- a/nv-monitor.c
+++ b/nv-monitor.c
@@ -78,6 +78,7 @@ static nvmlReturn_t (*pNvmlDeviceGetDecoderUtilization)(nvmlDevice_t, unsigned i
 
 static void *nvml_handle = NULL;
 static int   nvml_ok = 0;
+static unsigned int gpu_count = 0;      /* number of GPUs detected */
 static char  cpu_model_name[128] = "";  /* from /proc/cpuinfo */
 
 /* ── Constants ──────────────────────────────────────────────────────── */
@@ -196,7 +197,7 @@ static int    history_count = 0;
 static volatile sig_atomic_t g_quit = 0;
 static int sort_mode = 0; /* 0=by mem, 1=by pid */
 static int delay_ms = REFRESH_MS;
-static double last_gpu_util = 0; /* captured during draw for history */
+static double last_gpu_util = 0; /* average GPU util captured during draw for history */
 
 /* Command-line options */
 static FILE *log_fp = NULL;
@@ -763,7 +764,8 @@ static void log_csv_header(FILE *f) {
     fprintf(f, ",cpu_temp_c,cpu_freq_mhz");
     fprintf(f, ",mem_used_kb,mem_total_kb,mem_bufcache_kb");
     fprintf(f, ",swap_used_kb,swap_total_kb");
-    fprintf(f, ",gpu_util_pct,gpu_temp_c,gpu_power_mw,gpu_clock_mhz");
+    for (unsigned int g = 0; g < gpu_count; g++)
+        fprintf(f, ",gpu%u_util_pct,gpu%u_temp_c,gpu%u_power_mw,gpu%u_clock_mhz", g, g, g, g);
     for (int i = 0; i < rdma_count; i++)
         fprintf(f, ",rdma_%s_p%d_xmit_Bps,rdma_%s_p%d_recv_Bps",
                 rdma_ports[i].device, rdma_ports[i].port,
@@ -796,9 +798,9 @@ static void log_csv_row(FILE *f) {
     fprintf(f, ",%llu,%llu", mi.swap_used_kb, mi.swap_total_kb);
 
     /* GPU */
-    if (nvml_ok) {
+    for (unsigned int g = 0; g < gpu_count; g++) {
         nvmlDevice_t dev;
-        if (pNvmlDeviceGetHandleByIndex(0, &dev) == NVML_SUCCESS) {
+        if (pNvmlDeviceGetHandleByIndex(g, &dev) == NVML_SUCCESS) {
             nvmlUtilization_t util = {0};
             pNvmlDeviceGetUtilizationRates(dev, &util);
 
@@ -817,9 +819,8 @@ static void log_csv_row(FILE *f) {
         } else {
             fprintf(f, ",,,,");
         }
-    } else {
-        fprintf(f, ",,,,");
     }
+    if (gpu_count == 0) fprintf(f, ",,,,");
 
     for (int i = 0; i < rdma_count; i++)
         fprintf(f, ",%.0f,%.0f", rdma_ports[i].xmit_bytes_sec, rdma_ports[i].recv_bytes_sec);
@@ -1511,10 +1512,10 @@ static void draw_screen(void) {
         attroff(COLOR_PAIR(1));
         y += 2;
     } else {
-        unsigned int dev_count = 0;
-        pNvmlDeviceGetCount(&dev_count);
+        double gpu_util_sum = 0;
+        unsigned int gpu_util_n = 0;
 
-        for (unsigned int d = 0; d < dev_count && y < rows - 4; d++) {
+        for (unsigned int d = 0; d < gpu_count && y < rows - 4; d++) {
             nvmlDevice_t dev;
             if (pNvmlDeviceGetHandleByIndex(d, &dev) != NVML_SUCCESS) continue;
 
@@ -1523,7 +1524,8 @@ static void draw_screen(void) {
 
             nvmlUtilization_t util = {0};
             pNvmlDeviceGetUtilizationRates(dev, &util);
-            last_gpu_util = (double)util.gpu;
+            gpu_util_sum += (double)util.gpu;
+            gpu_util_n++;
 
             unsigned int temp = 0;
             pNvmlDeviceGetTemperature(dev, NVML_TEMPERATURE_GPU, &temp);
@@ -1709,6 +1711,8 @@ static void draw_screen(void) {
                 y++;
             }
         }
+
+        last_gpu_util = gpu_util_n > 0 ? gpu_util_sum / gpu_util_n : 0;
     }
 
     /* ── History chart (full width) ───────────────────────────────── */
@@ -1791,6 +1795,8 @@ int main(int argc, char *argv[]) {
 
     /* Load NVML */
     nvml_ok = (load_nvml() == 0);
+    if (nvml_ok && pNvmlDeviceGetCount)
+        pNvmlDeviceGetCount(&gpu_count);
 
     /* Read CPU info */
     read_cpu_model_name();


### PR DESCRIPTION
## Summary
- CSV logging now enumerates all GPUs (gpu0_*, gpu1_*, etc.)
- History chart shows average GPU utilization across all GPUs
- demo-load auto-detects GPU count and spawns one load thread per GPU
- TUI and Prometheus exporter already supported multi-GPU — no changes needed there

Closes #9

## Test plan
- [x] Builds clean with zero warnings on both nv-monitor and demo-load
- [x] `make test` passes
- [x] Single GPU (DGX Spark) — CSV columns show `gpu0_*`, demo-load targets GPU 0
- [ ] Multi-GPU system — verify per-GPU CSV columns and demo-load threads