### PR TITLE
Add Bearer token auth for Prometheus endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ sudo make install
 | `-i MS`   | Log interval in milliseconds               | 1000    |
 | `-n`      | Headless mode (no TUI, requires `-l`/`-p`) | off     |
 | `-p PORT` | Expose Prometheus metrics on PORT          | off     |
+| `-t TOKEN`| Require Bearer token for `/metrics`        | off     |
 | `-r MS`   | UI refresh interval in milliseconds        | 1000    |
 | `-v`      | Show version                               |         |
 | `-h`      | Show help                                  |         |
@@ -146,11 +147,33 @@ curl -s localhost:9101/metrics     # Check it works
 ```yaml
 scrape_configs:
   - job_name: 'nv-monitor'
+    authorization:
+      credentials: 'my-secret-token'
     static_configs:
       - targets: ['dgx-spark:9101']
 ```
 
 No new dependencies are required — the exporter uses POSIX sockets and adds ~128 KB of memory overhead.
+
+### Security
+
+The exporter supports optional Bearer token authentication:
+
+```bash
+./nv-monitor -p 9101 -t my-secret-token           # token via CLI flag
+NV_MONITOR_TOKEN=my-secret-token ./nv-monitor -p 9101  # token via env var (preferred)
+```
+
+The env var is preferred over `-t` since CLI arguments are visible in `ps` output. Without `-t` or `NV_MONITOR_TOKEN`, no auth is required (backwards compatible).
+
+**Design rationale:** nv-monitor is a lightweight, single-purpose endpoint — it intentionally does not implement TLS. For transport security, layer it with the tools you already have:
+
+- **Tailscale** — zero-config encrypted mesh, just run nv-monitor on the tailnet
+- **SSH tunnel** — `ssh -L 9101:localhost:9101 dgx-spark`
+- **Reverse proxy** — nginx/caddy with TLS termination
+- **Service mesh** — Istio, Linkerd, etc.
+
+This keeps the binary small, dependency-free, and composable with existing infrastructure.
 
 ## Synthetic Load Testing
 

--- a/nv-monitor.c
+++ b/nv-monitor.c
@@ -204,6 +204,7 @@ static FILE *log_fp = NULL;
 static int   log_interval_ms = 1000;
 static int   no_ui = 0;
 static int   prom_port = 0;  /* Prometheus metrics port (0 = disabled) */
+static const char *prom_token = NULL; /* Bearer token for /metrics auth */
 
 /* ── Signal handler ─────────────────────────────────────────────────── */
 
@@ -1226,6 +1227,21 @@ static void prom_handle(int fd) {
     if (n <= 0) return;
     req[n] = '\0';
 
+    /* Bearer token auth if configured */
+    if (prom_token) {
+        char expected[512];
+        snprintf(expected, sizeof(expected), "Authorization: Bearer %s", prom_token);
+        if (!strstr(req, expected)) {
+            static const char resp_401[] =
+                "HTTP/1.1 401 Unauthorized\r\n"
+                "Content-Type: text/plain\r\n"
+                "Connection: close\r\n\r\n"
+                "Unauthorized\n";
+            send(fd, resp_401, sizeof(resp_401) - 1, MSG_NOSIGNAL);
+            return;
+        }
+    }
+
     if (strstr(req, "GET /metrics")) {
         char body[PROM_BUF_SIZE];
         int bodylen = format_metrics(body, sizeof(body));
@@ -1335,6 +1351,7 @@ static void print_usage(const char *prog) {
         "  -i MS     Log interval in milliseconds (default: 1000)\n"
         "  -n        No UI (headless mode, requires -l or -p)\n"
         "  -p PORT   Expose Prometheus metrics on PORT\n"
+        "  -t TOKEN  Require Bearer token for /metrics (or NV_MONITOR_TOKEN env)\n"
         "  -r MS     UI refresh interval in milliseconds (default: 1000)\n"
         "  -v        Show version\n"
         "  -h        Show this help\n"
@@ -1764,18 +1781,23 @@ int main(int argc, char *argv[]) {
 
     const char *log_path = NULL;
     int opt;
-    while ((opt = getopt(argc, argv, "l:i:np:r:vh")) != -1) {
+    while ((opt = getopt(argc, argv, "l:i:np:t:r:vh")) != -1) {
         switch (opt) {
         case 'l': log_path = optarg; break;
         case 'i': log_interval_ms = atoi(optarg); break;
         case 'n': no_ui = 1; break;
         case 'p': prom_port = atoi(optarg); break;
+        case 't': prom_token = optarg; break;
         case 'r': delay_ms = atoi(optarg); break;
         case 'v': printf("nv-monitor %s\n", VERSION); return 0;
         case 'h': print_usage(argv[0]); return 0;
         default:  print_usage(argv[0]); return 1;
         }
     }
+
+    /* Token: CLI flag takes precedence, then env var */
+    if (!prom_token)
+        prom_token = getenv("NV_MONITOR_TOKEN");
 
     if (no_ui && !log_path && !prom_port) {
         fprintf(stderr, "Error: -n (no UI) requires -l <file> or -p <port>\n");


### PR DESCRIPTION
## Summary
- `-t TOKEN` or `NV_MONITOR_TOKEN` env var enables Bearer token auth on `/metrics`
- Returns 401 Unauthorized without valid token
- No token configured = no auth (backwards compatible)
- Env var preferred over CLI flag (CLI args visible in `ps` output)
- README documents security rationale: lightweight endpoint, layer TLS via Tailscale/SSH/reverse proxy

## Test plan
- [x] No token: 401
- [x] Wrong token: 401
- [x] Correct token: 200
- [x] Env var works
- [x] No `-t` or env var: no auth required (backwards compatible)
- [x] Prometheus `authorization.credentials` scrape config documented