### PR TITLE
Add legacy arm64 build for Jetson/older systems

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,6 +34,34 @@ jobs:
           name: demo-load-linux-arm64
           path: demo-load
 
+  # Legacy arm64 build (glibc 2.35) for Jetson and older systems
+  build-arm64-legacy:
+    runs-on: ubuntu-24.04-arm
+    container: ubuntu:22.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: apt-get update && apt-get install -y build-essential libncurses-dev git
+
+      - name: Build
+        run: make portable && make demo-load
+
+      - name: Test
+        run: make test
+
+      - name: Upload nv-monitor
+        uses: actions/upload-artifact@v4
+        with:
+          name: nv-monitor-linux-arm64-legacy
+          path: nv-monitor
+
+      - name: Upload demo-load
+        uses: actions/upload-artifact@v4
+        with:
+          name: demo-load-linux-arm64-legacy
+          path: demo-load
+
   build-amd64:
     runs-on: ubuntu-24.04
     steps:
@@ -62,7 +90,7 @@ jobs:
 
   release:
     if: startsWith(github.ref, 'refs/tags/v')
-    needs: [build-arm64, build-amd64]
+    needs: [build-arm64, build-arm64-legacy, build-amd64]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -78,6 +106,18 @@ jobs:
         with:
           name: demo-load-linux-arm64
           path: arm64
+
+      - name: Download arm64-legacy artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: nv-monitor-linux-arm64-legacy
+          path: arm64-legacy
+
+      - name: Download arm64-legacy demo-load
+        uses: actions/download-artifact@v4
+        with:
+          name: demo-load-linux-arm64-legacy
+          path: arm64-legacy
 
       - name: Download amd64 artifacts
         uses: actions/download-artifact@v4
@@ -95,6 +135,8 @@ jobs:
         run: |
           mv arm64/nv-monitor nv-monitor-linux-arm64
           mv arm64/demo-load demo-load-linux-arm64
+          mv arm64-legacy/nv-monitor nv-monitor-linux-arm64-legacy
+          mv arm64-legacy/demo-load demo-load-linux-arm64-legacy
           mv amd64/nv-monitor nv-monitor-linux-amd64
           mv amd64/demo-load demo-load-linux-amd64
           chmod +x nv-monitor-linux-* demo-load-linux-*
@@ -105,5 +147,7 @@ jobs:
           files: |
             nv-monitor-linux-arm64
             nv-monitor-linux-amd64
+            nv-monitor-linux-arm64-legacy
             demo-load-linux-arm64
             demo-load-linux-amd64
+            demo-load-linux-arm64-legacy


### PR DESCRIPTION
## Summary
Adds a CI build using Ubuntu 22.04 container (glibc 2.35) for arm64 devices that can't run the Ubuntu 24.04 binary (glibc 2.38).

Covers all current JetPack releases (Jetson Orin Nano, NX, AGX) and other older arm64 Linux systems.

Releases will now include `nv-monitor-linux-arm64-legacy` and `demo-load-linux-arm64-legacy` alongside the standard binaries.

## Test plan
- [ ] CI builds successfully in ubuntu:22.04 container
- [ ] Binary runs on Jetson Orin Nano (JetPack 6)