### PR TITLE
Add Jetson Orin/Tegra GPU support

### DIFF
--- a/DEMO-LOAD.md
+++ b/DEMO-LOAD.md
@@ -67,7 +67,9 @@ Loads a small PTX kernel (FMA-heavy compute loop) via the CUDA driver API at run
 2. During the busy portion, kernels are queued back-to-back on a CUDA stream with no synchronisation between launches — keeping the GPU pipeline fully saturated
 3. A single sync at the end, then sleep for the idle portion
 
-This matches how NVML measures utilisation (fraction of time the GPU was active), producing smooth, realistic-looking load curves.
+This matches how NVML measures utilisation (fraction of time the GPU was active), producing smooth, realistic-looking load curves on larger GPUs.
+
+**Note:** On smaller GPUs (e.g. Jetson Orin Nano) the kernel executes very fast (~0.03ms), so the duty cycle appears more binary (on/off) rather than smoothly sinusoidal at NVML's ~1s sampling rate. This is expected — the load is still varying over time, just with sharper transitions. On larger GPUs (DGX Spark, RTX, A100) the curves are smoother.
 
 ## Example: Multi-Node Production Test
 

--- a/nv-monitor.c
+++ b/nv-monitor.c
@@ -525,7 +525,8 @@ static void detect_tegra_gpu(void) {
         if (!f) break;
         if (fgets(type, sizeof(type), f)) {
             type[strcspn(type, "\n\r")] = '\0';
-            if (strcmp(type, "GPU-therm") == 0) {
+            if (strcasecmp(type, "GPU-therm") == 0 ||
+                strcasecmp(type, "gpu-thermal") == 0) {
                 tegra_gpu_therm_zone = i;
                 fclose(f);
                 break;


### PR DESCRIPTION
## Summary
Adds full GPU monitoring support for NVIDIA Jetson devices (Orin Nano, NX, AGX, Xavier, TX2, Nano) where NVML returns SUCCESS but with zero/garbage data for the integrated GPU.

**Fixes:**
- GPU utilization via Tegra sysfs (`/sys/devices/platform/bus@0/17000000.gpu/load` or `/sys/devices/gpu.0/load`) — auto-detected across JetPack versions
- GPU temperature via `gpu-thermal` / `GPU-therm` thermal zone — case-insensitive matching
- Garbage process filtering — validates PIDs, skips 0 and overflow values from Jetson NVML
- Cortex-A78AE core label (`A78A`) plus A76, A75, A57, A53 for older Jetson boards

**Design:** When Tegra GPU sysfs is detected at startup, it is always preferred over NVML for utilization and temperature. NVML is still used for device name, process listing, and other metadata where it works.

Tested on:
- [x] DGX Spark (Grace + GB10) — no regression, Tegra sysfs not detected, NVML path unchanged
- [x] Jetson Orin Nano Super (JetPack 6) — GPU util, temp, history chart all working
- [x] demo-load --gpu confirmed functional on both platforms

Closes #10

## Test plan
- [x] GPU utilization bar shows real values under load (demo-load --gpu)
- [x] GPU temperature reads from gpu-thermal zone
- [x] No garbage processes in process list
- [x] CPU cores show A78A labels
- [x] Header shows device tree model name
- [x] History chart shows GPU activity
- [x] make test passes