### PR TITLE
Scrollable CPU section with adjustable columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ sudo make install
 
 | Flag      | Description                                | Default |
 |-----------|--------------------------------------------|---------|
+| `-c COLS` | CPU display columns (1-4, 0=auto)          | auto    |
 | `-l FILE` | Log statistics to CSV file                 | off     |
 | `-i MS`   | Log interval in milliseconds               | 1000    |
 | `-n`      | Headless mode (no TUI, requires `-l`/`-p`) | off     |
@@ -102,11 +103,15 @@ sudo make install
 
 ### Interactive controls
 
-| Key     | Action                              |
-|---------|-------------------------------------|
-| `q`/Esc | Quit                                |
-| `s`     | Toggle sort (GPU memory / PID)      |
-| `+`/`-` | Adjust refresh rate (250ms steps)   |
+| Key         | Action                                       |
+|-------------|----------------------------------------------|
+| `q`/Esc     | Quit                                         |
+| `s`         | Toggle sort (GPU memory / PID)               |
+| `c`         | Cycle CPU column count (auto → 1 → 2 → 3 → 4)|
+| `j`/`k` or ↑/↓ | Scroll CPU cores when they exceed the viewport |
+| `+`/`-`     | Adjust refresh rate (250ms steps)            |
+
+The CPU section auto-selects the column count based on terminal width and adapts on resize. When cores exceed the available vertical space, a scroll indicator `[first-last] ↑↓` appears on the CPU header line. Use `-c N` to override the auto column count at startup.
 
 ## Prometheus Metrics
 

--- a/nv-monitor.c
+++ b/nv-monitor.c
@@ -204,6 +204,7 @@ static int delay_ms = REFRESH_MS;
 static double last_gpu_util = 0; /* average GPU util captured during draw for history */
 static int cpu_columns = 0;  /* 0 = auto, 1-4 = user override */
 static int cpu_scroll  = 0;  /* first visible core row offset */
+static int skip_history_once = 0; /* suppress history chart for one frame after resize */
 
 /* Command-line options */
 static FILE *log_fp = NULL;
@@ -844,11 +845,16 @@ static void draw_history_chart(int top_y, int total_w, int chart_h) {
     int cpu_w = bar_w / 2;
     int gpu_w = bar_w - cpu_w;
 
+    /* Clamp visible samples to what fits in avail_w. On very narrow terminals
+     * this shows fewer samples rather than overflowing into other lines. */
+    int max_visible = avail_w / col_w;
+    if (max_visible < 1) return;
     int visible = n;
+    if (visible > max_visible) visible = max_visible;
 
-    /* Right-align: new samples appear on the right, chart grows leftward */
-    int chart_total = HISTORY_LEN * col_w;
-    int x_start = left_x + (avail_w - chart_total) + (HISTORY_LEN - visible) * col_w;
+    /* Right-align: new samples appear on the right */
+    int chart_total = visible * col_w;
+    int x_start = right_x - chart_total;
 
     for (int s = 0; s < visible; s++) {
         int idx = (history_pos - visible + s + HISTORY_LEN) % HISTORY_LEN;
@@ -893,8 +899,8 @@ static void draw_history_chart(int top_y, int total_w, int chart_h) {
 
     /* X-axis: t-N labels (seconds ago), right-aligned with 0 on the right */
     int x_row = top_y + chart_h;
-    for (int t = 0; t < HISTORY_LEN; t += 5) {
-        int s = HISTORY_LEN - 1 - t; /* sample index from right */
+    for (int t = 0; t < visible; t += 5) {
+        int s = visible - 1 - t; /* sample index from right */
         int x = x_start + s * col_w;
         if (x >= left_x && x < right_x - 2)
             mvprintw(x_row, x, "%-3d", t);
@@ -1630,9 +1636,30 @@ static void draw_screen(void) {
     int total_core_rows = (num_cpus + ncols - 1) / ncols;
     if (total_core_rows < 1 && num_cpus > 0) total_core_rows = 1;
 
-    /* CPU vertical budget: total rows minus fixed sections */
-    int fixed_rows = 15 + (gpu_count > 3 ? 12 : gpu_count * 4);
+    /* Narrow terminal: put "Overall:" on its own line to avoid collision */
+    int narrow_header = (cols < 90);
+
+    /* CPU vertical budget: total rows minus fixed sections.
+     * Per-GPU estimate: header(1) + util(1) + vram(1) + enc/dec(1) + blank(1)
+     * + proc header(1) + ~2 procs(2) + other row(1) = ~10 rows.
+     * Cap at 3 GPUs visible — beyond that, scrolling the GPU section is a
+     * separate problem. */
+    int gpu_rows = (gpu_count == 0 ? 0 :
+                    (gpu_count > 3 ? 30 : (int)gpu_count * 10));
+    int header_rows_extra = narrow_header ? 1 : 0;
+    /* base: title(2) + CPU header(1) + blank(1) + mem(3) + blank(1) +
+     * separator(1) + blank(1) + footer(1) = 11 */
+    int base_fixed = 11 + gpu_rows + header_rows_extra;
+    int history_rows = 7;
+    int fixed_rows = base_fixed + history_rows;
     int cpu_max_rows = rows - fixed_rows;
+    /* If too cramped, drop history to give cores more room */
+    int show_history = 1;
+    if (cpu_max_rows < 5) {
+        show_history = 0;
+        fixed_rows = base_fixed;
+        cpu_max_rows = rows - fixed_rows;
+    }
     if (cpu_max_rows < 3) cpu_max_rows = 3;
     if (cpu_max_rows > total_core_rows) cpu_max_rows = total_core_rows;
 
@@ -1649,8 +1676,6 @@ static void draw_screen(void) {
     mvprintw(y, 1, "CPU");
     attroff(A_BOLD | COLOR_PAIR(3));
     printw("  %d cores", num_cpus);
-    if (cpu_freq > 0) printw("  %d MHz", cpu_freq);
-    if (cpu_temp > 0) printw("  %d C", cpu_temp);
     if (scrollable) {
         int first_core = cpu_scroll * ncols;
         int last_core = (cpu_scroll + cpu_max_rows) * ncols - 1;
@@ -1658,17 +1683,30 @@ static void draw_screen(void) {
         const char *up   = (cpu_scroll > 0) ? "\xe2\x86\x91" : " ";        /* ↑ */
         const char *down = (cpu_scroll < max_scroll) ? "\xe2\x86\x93" : " "; /* ↓ */
         attron(COLOR_PAIR(8));
-        printw("  [%d-%d of %d] ", first_core, last_core, num_cpus);
+        printw(" [%d-%d] ", first_core, last_core);
         attroff(COLOR_PAIR(8));
         attron(A_BOLD | COLOR_PAIR(6));
         printw("%s%s", up, down);
         attroff(A_BOLD | COLOR_PAIR(6));
     }
+    if (cpu_freq > 0) printw("  %d MHz", cpu_freq);
+    if (cpu_temp > 0) printw("  %d C", cpu_temp);
 
-    attron(A_BOLD);
-    mvprintw(y, cols / 2 + 1, "Overall: ");
-    attroff(A_BOLD);
-    {
+    if (narrow_header) {
+        /* Overall bar on its own line (full width) */
+        y += 1;
+        attron(A_BOLD);
+        mvprintw(y, 1, "Overall:");
+        attroff(A_BOLD);
+        int bw = cols - 19;
+        if (bw < 10) bw = 10;
+        int color = cpu_pct[0] > 90 ? 1 : (cpu_pct[0] > 60 ? 3 : 2);
+        draw_bar(y, 11, bw, cpu_pct[0], color);
+        mvprintw(y, 11 + bw, " %4.1f%%", cpu_pct[0]);
+    } else {
+        attron(A_BOLD);
+        mvprintw(y, cols / 2 + 1, "Overall: ");
+        attroff(A_BOLD);
         int bw = cols / 2 - 17;
         if (bw < 10) bw = 10;
         int color = cpu_pct[0] > 90 ? 1 : (cpu_pct[0] > 60 ? 3 : 2);
@@ -1962,8 +2000,8 @@ static void draw_screen(void) {
                     else
                         snprintf(mb, sizeof(mb), "N/A");
 
-                    int name_max = cols - 54;
-                    if (name_max < 10) name_max = 10;
+                    int name_max = cols - 52;
+                    if (name_max < 0) name_max = 0;
                     char truncname[256];
                     snprintf(truncname, sizeof(truncname), "%-.*s", name_max, p->name);
 
@@ -1998,13 +2036,14 @@ static void draw_screen(void) {
 
     /* ── History chart (full width) ───────────────────────────────── */
     record_history(cpu_pct[0], last_gpu_util);
-    {
+    if (show_history && !skip_history_once) {
         int chart_h = 5;
         int chart_top = rows - 3 - chart_h; /* -3: footer + x-axis + gap */
         if (chart_top > y + 1 && cols > 20) {
             draw_history_chart(chart_top, cols, chart_h);
         }
     }
+    skip_history_once = 0;
 
     /* ── Footer ─────────────────────────────────────────────────────── */
     attron(COLOR_PAIR(8));
@@ -2205,15 +2244,19 @@ int main(int argc, char *argv[]) {
                 } else if (ch == 'c' || ch == 'C') {
                     cpu_columns = (cpu_columns + 1) % 5; /* 0=auto,1,2,3,4 */
                     cpu_scroll = 0;
+                    skip_history_once = 1;
                     break;
                 } else if (ch == 'j' || ch == KEY_DOWN) {
                     cpu_scroll++;
+                    skip_history_once = 1;
                     break;
                 } else if (ch == 'k' || ch == KEY_UP) {
                     if (cpu_scroll > 0) cpu_scroll--;
+                    skip_history_once = 1;
                     break;
                 } else if (ch == KEY_RESIZE) {
                     cpu_scroll = 0;
+                    skip_history_once = 1;
                     break; /* redraw immediately */
                 }
                 usleep(50000);

--- a/nv-monitor.c
+++ b/nv-monitor.c
@@ -202,6 +202,8 @@ static volatile sig_atomic_t g_quit = 0;
 static int sort_mode = 0; /* 0=by mem, 1=by pid */
 static int delay_ms = REFRESH_MS;
 static double last_gpu_util = 0; /* average GPU util captured during draw for history */
+static int cpu_columns = 0;  /* 0 = auto, 1-4 = user override */
+static int cpu_scroll  = 0;  /* first visible core row offset */
 
 /* Command-line options */
 static FILE *log_fp = NULL;
@@ -1556,6 +1558,7 @@ static void print_usage(const char *prog) {
         "Usage: %s [OPTIONS]\n"
         "\n"
         "Options:\n"
+        "  -c COLS   CPU display columns (1-4, default: auto)\n"
         "  -l FILE   Log statistics to CSV file\n"
         "  -i MS     Log interval in milliseconds (default: 1000)\n"
         "  -n        No UI (headless mode, requires -l or -p)\n"
@@ -1614,18 +1617,54 @@ static void draw_screen(void) {
     int cpu_temp = read_cpu_temp();
     int cpu_freq = read_cpu_freq_mhz();
 
+    /* Auto-calculate column count: ~36 chars per column minimum */
+    int ncols;
+    if (cpu_columns > 0) {
+        ncols = cpu_columns;
+    } else {
+        ncols = cols / 36;
+        if (ncols < 1) ncols = 1;
+        if (ncols > 4) ncols = 4;
+    }
+    /* Don't have more columns than cores */
+    int total_core_rows = (num_cpus + ncols - 1) / ncols;
+    if (total_core_rows < 1 && num_cpus > 0) total_core_rows = 1;
+
+    /* CPU vertical budget: total rows minus fixed sections */
+    int fixed_rows = 15 + (gpu_count > 3 ? 12 : gpu_count * 4);
+    int cpu_max_rows = rows - fixed_rows;
+    if (cpu_max_rows < 3) cpu_max_rows = 3;
+    if (cpu_max_rows > total_core_rows) cpu_max_rows = total_core_rows;
+
+    /* Clamp scroll */
+    int max_scroll = total_core_rows - cpu_max_rows;
+    if (max_scroll < 0) max_scroll = 0;
+    if (cpu_scroll > max_scroll) cpu_scroll = max_scroll;
+    if (cpu_scroll < 0) cpu_scroll = 0;
+
+    int scrollable = (total_core_rows > cpu_max_rows);
+
+    /* CPU header */
     attron(A_BOLD | COLOR_PAIR(3));
     mvprintw(y, 1, "CPU");
     attroff(A_BOLD | COLOR_PAIR(3));
     printw("  %d cores", num_cpus);
     if (cpu_freq > 0) printw("  %d MHz", cpu_freq);
     if (cpu_temp > 0) printw("  %d C", cpu_temp);
+    if (scrollable) {
+        int first_core = cpu_scroll * ncols;
+        int last_core = (cpu_scroll + cpu_max_rows) * ncols - 1;
+        if (last_core >= num_cpus) last_core = num_cpus - 1;
+        attron(COLOR_PAIR(8));
+        printw("  [%d-%d of %d]", first_core, last_core, num_cpus);
+        attroff(COLOR_PAIR(8));
+    }
 
     attron(A_BOLD);
     mvprintw(y, cols / 2 + 1, "Overall: ");
     attroff(A_BOLD);
     {
-        int bw = cols / 2 - 17; /* 10 label + 7 suffix " xxx.x%" */
+        int bw = cols / 2 - 17;
         if (bw < 10) bw = 10;
         int color = cpu_pct[0] > 90 ? 1 : (cpu_pct[0] > 60 ? 3 : 2);
         draw_bar(y, cols / 2 + 10, bw, cpu_pct[0], color);
@@ -1633,40 +1672,30 @@ static void draw_screen(void) {
     }
     y += 1;
 
-    /* Per-core bars - two columns */
-    int half = (num_cpus + 1) / 2;
+    /* Per-core bars - N columns, scrollable */
     int lbl_w = 9; /* "XX YYYY " — core number + type label */
-    int bar_w = cols / 2 - lbl_w - 7; /* label + suffix " xxx.x%" */
+    int col_w = cols / ncols;
+    int bar_w = col_w - lbl_w - 8; /* label + suffix " xxx.x%" + margin */
     if (bar_w < 5) bar_w = 5;
 
-    for (int i = 0; i < half; i++) {
-        int cpu_l = i;
-        int cpu_r = i + half;
+    int visible = cpu_max_rows;
+    for (int r = 0; r < visible; r++) {
+        for (int c = 0; c < ncols; c++) {
+            int core_idx = (cpu_scroll + r) * ncols + c;
+            if (core_idx >= num_cpus) break;
+            int x = c * col_w + 1;
 
-        /* Left column */
-        int color = cpu_pct[cpu_l + 1] > 90 ? 1 : (cpu_pct[cpu_l + 1] > 60 ? 3 : 2);
-        const char *lbl_l = cpu_part_label(cpu_l);
-        mvprintw(y, 1, "%2d ", cpu_l);
-        attron(COLOR_PAIR(8));
-        printw("%-4s ", lbl_l);
-        attroff(COLOR_PAIR(8));
-        draw_bar(y, 1 + lbl_w, bar_w, cpu_pct[cpu_l + 1], color);
-        mvprintw(y, 1 + lbl_w + bar_w, " %4.1f%%", cpu_pct[cpu_l + 1]);
-
-        /* Right column */
-        if (cpu_r < num_cpus) {
-            int rx = cols / 2 + 1;
-            color = cpu_pct[cpu_r + 1] > 90 ? 1 : (cpu_pct[cpu_r + 1] > 60 ? 3 : 2);
-            const char *lbl_r = cpu_part_label(cpu_r);
-            mvprintw(y, rx, "%2d ", cpu_r);
+            int color = cpu_pct[core_idx + 1] > 90 ? 1 :
+                       (cpu_pct[core_idx + 1] > 60 ? 3 : 2);
+            const char *lbl = cpu_part_label(core_idx);
+            mvprintw(y, x, "%2d ", core_idx);
             attron(COLOR_PAIR(8));
-            printw("%-4s ", lbl_r);
+            printw("%-4s ", lbl);
             attroff(COLOR_PAIR(8));
-            draw_bar(y, rx + lbl_w - 1, bar_w, cpu_pct[cpu_r + 1], color);
-            mvprintw(y, rx + lbl_w - 1 + bar_w, " %4.1f%%", cpu_pct[cpu_r + 1]);
+            draw_bar(y, x + lbl_w, bar_w, cpu_pct[core_idx + 1], color);
+            mvprintw(y, x + lbl_w + bar_w, " %4.1f%%", cpu_pct[core_idx + 1]);
         }
         y++;
-        if (y >= rows - 2) break;
     }
 
     y += 1;
@@ -1986,6 +2015,14 @@ static void draw_screen(void) {
     attroff(A_BOLD | COLOR_PAIR(7));
     printw(":sort ");
     attron(A_BOLD | COLOR_PAIR(7));
+    printw("c");
+    attroff(A_BOLD | COLOR_PAIR(7));
+    printw(":cols ");
+    attron(A_BOLD | COLOR_PAIR(7));
+    printw("j/k");
+    attroff(A_BOLD | COLOR_PAIR(7));
+    printw(":scroll ");
+    attron(A_BOLD | COLOR_PAIR(7));
     printw("+/-");
     attroff(A_BOLD | COLOR_PAIR(7));
     printw(":speed  ");
@@ -2011,8 +2048,9 @@ int main(int argc, char *argv[]) {
 
     const char *log_path = NULL;
     int opt;
-    while ((opt = getopt(argc, argv, "l:i:np:t:r:vh")) != -1) {
+    while ((opt = getopt(argc, argv, "c:l:i:np:t:r:vh")) != -1) {
         switch (opt) {
+        case 'c': cpu_columns = atoi(optarg); if (cpu_columns < 0 || cpu_columns > 4) cpu_columns = 0; break;
         case 'l': log_path = optarg; break;
         case 'i': log_interval_ms = atoi(optarg); break;
         case 'n': no_ui = 1; break;
@@ -2159,7 +2197,18 @@ int main(int argc, char *argv[]) {
                     if (delay_ms > 250) delay_ms -= 250;
                 } else if (ch == '-' || ch == '_') {
                     if (delay_ms < 5000) delay_ms += 250;
+                } else if (ch == 'c' || ch == 'C') {
+                    cpu_columns = (cpu_columns + 1) % 5; /* 0=auto,1,2,3,4 */
+                    cpu_scroll = 0;
+                    break;
+                } else if (ch == 'j' || ch == KEY_DOWN) {
+                    cpu_scroll++;
+                    break;
+                } else if (ch == 'k' || ch == KEY_UP) {
+                    if (cpu_scroll > 0) cpu_scroll--;
+                    break;
                 } else if (ch == KEY_RESIZE) {
+                    cpu_scroll = 0;
                     break; /* redraw immediately */
                 }
                 usleep(50000);

--- a/nv-monitor.c
+++ b/nv-monitor.c
@@ -1655,9 +1655,14 @@ static void draw_screen(void) {
         int first_core = cpu_scroll * ncols;
         int last_core = (cpu_scroll + cpu_max_rows) * ncols - 1;
         if (last_core >= num_cpus) last_core = num_cpus - 1;
+        const char *up   = (cpu_scroll > 0) ? "\xe2\x86\x91" : " ";        /* ↑ */
+        const char *down = (cpu_scroll < max_scroll) ? "\xe2\x86\x93" : " "; /* ↓ */
         attron(COLOR_PAIR(8));
-        printw("  [%d-%d of %d]", first_core, last_core, num_cpus);
+        printw("  [%d-%d of %d] ", first_core, last_core, num_cpus);
         attroff(COLOR_PAIR(8));
+        attron(A_BOLD | COLOR_PAIR(6));
+        printw("%s%s", up, down);
+        attroff(A_BOLD | COLOR_PAIR(6));
     }
 
     attron(A_BOLD);


### PR DESCRIPTION
## Summary
Replaces the fixed 2-column CPU layout with an auto-adjusting N-column scrollable viewport.

- **Auto columns**: calculates optimal column count from terminal width (~36 chars/column), 1-4 columns
- **`-c N` flag**: set initial column count (1-4, 0 or omit for auto)
- **`c` key**: cycle columns at runtime (auto → 1 → 2 → 3 → 4 → auto)
- **`j`/`k` or arrows**: scroll CPU cores when they exceed available rows
- **Scroll indicator**: `[cores 0-19 of 142]` shown on CPU header when scrolling is active
- **Resize-safe**: column count and scroll reset on terminal resize

Handles 6 cores (Jetson) to 512+ cores (GB200 NVL) gracefully. No new memory allocations — just two static integers.

Closes #26

## Test plan
- [x] Builds clean, zero warnings
- [x] `make test` passes
- [x] `soak-test.sh 2` — PASS, RSS stable (+12 KB, same as baseline)
- [ ] Manual: cycle columns with `c`, verify bars resize
- [ ] Manual: scroll with `j`/`k` on system with many cores
- [ ] Manual: resize terminal, verify layout adapts and scroll resets