### PR TITLE
Update platform support table

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,10 +214,11 @@ make demo-load
 | Platform | Status |
 |----------|--------|
 | DGX Spark (aarch64, Grace + GB10) | Primary target — full support including unified memory, HugePages, big.LITTLE core labels |
+| GB200 NVL (aarch64, up to 208 GPUs) | Supported — dynamic allocation scales to any CPU/GPU count, scrollable TUI |
+| Jetson Orin (Nano / NX / AGX) | GPU via Tegra sysfs, A78AE core labels, legacy glibc binary available |
 | Any Linux + NVIDIA GPU (x86_64) | Fully supported — CPU, memory, GPU, processes, Prometheus exporter |
 | Linux without NVIDIA GPU | CPU and memory monitoring only, GPU section shows "NVML not available" |
 | RDMA / InfiniBand | Community-verified on real hardware — auto-detected via `/sys/class/infiniband/`, feedback welcome |
-| Jetson Orin (Nano / NX / AGX) | GPU via Tegra sysfs, A78AE core labels, legacy glibc binary available |
 
 ### A note on RDMA and cross-node bandwidth
 


### PR DESCRIPTION
Add GB200 NVL with dynamic allocation and scrollable TUI. Reorder table from largest to smallest.