### PR TITLE
feat(prometheus): export disk usage metrics (nv_disk_*)

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,9 @@ curl -s localhost:9101/metrics     # Check it works
 | `nv_memory_bufcache_bytes` | gauge | | Buffer and cache memory |
 | `nv_swap_total_bytes` | gauge | | Total swap |
 | `nv_swap_used_bytes` | gauge | | Swap used |
+| `nv_disk_total_bytes` | gauge | `mountpoint`, `device`, `fstype` | Filesystem total size (per real mount) |
+| `nv_disk_used_bytes` | gauge | `mountpoint`, `device`, `fstype` | Filesystem used bytes |
+| `nv_disk_avail_bytes` | gauge | `mountpoint`, `device`, `fstype` | Filesystem available bytes |
 | `nv_gpu_info` | gauge | `gpu`, `name` | GPU device name |
 | `nv_gpu_utilization_percent` | gauge | `gpu` | GPU compute utilization |
 | `nv_gpu_temperature_celsius` | gauge | `gpu` | GPU temperature |

--- a/nv-monitor.c
+++ b/nv-monitor.c
@@ -25,6 +25,8 @@
 #include <locale.h>
 #include <sys/sysinfo.h>
 #include <sys/stat.h>
+#include <sys/statvfs.h>
+#include <mntent.h>
 #include <getopt.h>
 #include <sys/socket.h>
 #include <netinet/in.h>
@@ -1426,6 +1428,94 @@ static int format_metrics(char *buf, int buflen) {
            "nv_network_transmit_bytes_per_second %.0f\n",
            net_totals.rx_bytes, net_totals.tx_bytes,
            net_totals.rx_bytes_sec, net_totals.tx_bytes_sec);
+    }
+
+    /* Disk usage per real mountpoint (skip pseudo/virtual fs) */
+    {
+        struct {
+            char mount[256];
+            char fstype[32];
+            char device[128];
+            unsigned long long total;
+            unsigned long long avail;
+            unsigned long long used;
+        } disks[64];
+        int n_disks = 0;
+
+        FILE *mf = setmntent("/proc/mounts", "r");
+        if (mf) {
+            struct mntent *me;
+            while ((me = getmntent(mf)) != NULL && n_disks < 64) {
+                /* Skip pseudo / virtual filesystems */
+                if (strcmp(me->mnt_type, "tmpfs") == 0 ||
+                    strcmp(me->mnt_type, "devtmpfs") == 0 ||
+                    strcmp(me->mnt_type, "overlay") == 0 ||
+                    strcmp(me->mnt_type, "squashfs") == 0 ||
+                    strcmp(me->mnt_type, "proc") == 0 ||
+                    strcmp(me->mnt_type, "sysfs") == 0 ||
+                    strcmp(me->mnt_type, "cgroup") == 0 ||
+                    strcmp(me->mnt_type, "cgroup2") == 0 ||
+                    strcmp(me->mnt_type, "devpts") == 0 ||
+                    strcmp(me->mnt_type, "mqueue") == 0 ||
+                    strcmp(me->mnt_type, "hugetlbfs") == 0 ||
+                    strcmp(me->mnt_type, "debugfs") == 0 ||
+                    strcmp(me->mnt_type, "tracefs") == 0 ||
+                    strcmp(me->mnt_type, "fusectl") == 0 ||
+                    strcmp(me->mnt_type, "configfs") == 0 ||
+                    strcmp(me->mnt_type, "pstore") == 0 ||
+                    strcmp(me->mnt_type, "bpf") == 0 ||
+                    strcmp(me->mnt_type, "autofs") == 0 ||
+                    strcmp(me->mnt_type, "binfmt_misc") == 0 ||
+                    strcmp(me->mnt_type, "rpc_pipefs") == 0 ||
+                    strcmp(me->mnt_type, "nsfs") == 0 ||
+                    strcmp(me->mnt_type, "securityfs") == 0 ||
+                    strcmp(me->mnt_type, "efivarfs") == 0 ||
+                    strncmp(me->mnt_fsname, "/dev/loop", 9) == 0)
+                    continue;
+                /* Only real device-backed mounts */
+                if (me->mnt_fsname[0] != '/')
+                    continue;
+
+                struct statvfs sv;
+                if (statvfs(me->mnt_dir, &sv) != 0)
+                    continue;
+
+                unsigned long long total = (unsigned long long)sv.f_blocks * sv.f_frsize;
+                unsigned long long avail = (unsigned long long)sv.f_bavail * sv.f_frsize;
+                if (total == 0)
+                    continue;
+                unsigned long long used = total - (unsigned long long)sv.f_bfree * sv.f_frsize;
+
+                snprintf(disks[n_disks].mount, sizeof(disks[n_disks].mount), "%s", me->mnt_dir);
+                snprintf(disks[n_disks].fstype, sizeof(disks[n_disks].fstype), "%s", me->mnt_type);
+                snprintf(disks[n_disks].device, sizeof(disks[n_disks].device), "%s", me->mnt_fsname);
+                disks[n_disks].total = total;
+                disks[n_disks].avail = avail;
+                disks[n_disks].used = used;
+                n_disks++;
+            }
+            endmntent(mf);
+        }
+
+        if (n_disks > 0) {
+            PM("# HELP nv_disk_total_bytes Filesystem total size\n"
+               "# TYPE nv_disk_total_bytes gauge\n");
+            for (int i = 0; i < n_disks; i++)
+                PM("nv_disk_total_bytes{mountpoint=\"%s\",device=\"%s\",fstype=\"%s\"} %llu\n",
+                   disks[i].mount, disks[i].device, disks[i].fstype, disks[i].total);
+
+            PM("# HELP nv_disk_used_bytes Filesystem used bytes\n"
+               "# TYPE nv_disk_used_bytes gauge\n");
+            for (int i = 0; i < n_disks; i++)
+                PM("nv_disk_used_bytes{mountpoint=\"%s\",device=\"%s\",fstype=\"%s\"} %llu\n",
+                   disks[i].mount, disks[i].device, disks[i].fstype, disks[i].used);
+
+            PM("# HELP nv_disk_avail_bytes Filesystem available bytes\n"
+               "# TYPE nv_disk_avail_bytes gauge\n");
+            for (int i = 0; i < n_disks; i++)
+                PM("nv_disk_avail_bytes{mountpoint=\"%s\",device=\"%s\",fstype=\"%s\"} %llu\n",
+                   disks[i].mount, disks[i].device, disks[i].fstype, disks[i].avail);
+        }
     }
 
     /* GPU — collect data first, then format grouped by metric family */


### PR DESCRIPTION
## Summary

Adds three new Prometheus gauges per real device-backed mountpoint:

- `nv_disk_total_bytes{mountpoint,device,fstype}`
- `nv_disk_used_bytes{mountpoint,device,fstype}`
- `nv_disk_avail_bytes{mountpoint,device,fstype}`

This complements the existing `nv_memory_*` / `nv_swap_*` series so operators can build complete capacity dashboards from a single exporter.

## Implementation

- Reads `/proc/mounts` via `setmntent(3)` and queries each entry with `statvfs(2)`.
- Skips pseudo / virtual filesystems: tmpfs, devtmpfs, overlay, squashfs, efivarfs, cgroup[2], proc, sysfs, devpts, mqueue, hugetlbfs, debugfs, tracefs, fusectl, configfs, pstore, bpf, autofs, binfmt_misc, rpc_pipefs, nsfs, securityfs.
- Skips `/dev/loop*` and any source path that does not start with `/`.
- Hard cap of 64 mounts to bound output size on hosts with pathological mount tables.

## Build / dependencies

No new dependencies. `statvfs.h` and `mntent.h` are part of glibc and are already available wherever nv-monitor builds.

## Sample exposition

```
# HELP nv_disk_total_bytes Filesystem total size
# TYPE nv_disk_total_bytes gauge
nv_disk_total_bytes{mountpoint="/",device="/dev/nvme0n1p2",fstype="ext4"} 982819848192
nv_disk_total_bytes{mountpoint="/boot/efi",device="/dev/nvme0n1p1",fstype="vfat"} 535805952
# HELP nv_disk_used_bytes Filesystem used bytes
# TYPE nv_disk_used_bytes gauge
nv_disk_used_bytes{mountpoint="/",device="/dev/nvme0n1p2",fstype="ext4"} 638779076608
# HELP nv_disk_avail_bytes Filesystem available bytes
# TYPE nv_disk_avail_bytes gauge
nv_disk_avail_bytes{mountpoint="/",device="/dev/nvme0n1p2",fstype="ext4"} 294040735744
```

## Test plan

- [x] Compiles clean with the existing Makefile (`-O3 -march=native -flto -Wall -Wextra -std=gnu11`) on aarch64 (NVIDIA DGX Spark, GB10).
- [x] `curl :9101/metrics` returns the new families with values matching `df -B1` to within rounding.
- [x] Pseudo / virtual mounts (tmpfs, efivarfs, devtmpfs, etc.) are absent from the output.
- [x] Service `systemctl restart` and full `stop / start` cycle preserve mount enumeration.
- [x] No regression in `nv_cpu_*`, `nv_memory_*`, `nv_swap_*`, `nv_gpu_*`, `nv_rdma_*` families.
- [x] README metrics table updated.

## Notes

- The `device` label uses whatever `/proc/mounts` reports as the source (typically the block device path).
- For the rare case of a mount where `statvfs` fails (e.g. an unresponsive NFS), the entry is silently skipped — the rest of the output still completes normally.